### PR TITLE
gitignore: fix examples path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 examples/simple_mdx2wav/objs
 examples/simple_mdx2wav/simple_mdx2wav
 examples/simple_mdx2wav/simple_mdx2wav.exe
-examples/simple_player/objs
-examples/simple_player/simple_player
-examples/simple_player/simple_player.exe
+examples/simple_mdx_player/objs
+examples/simple_mdx_player/simple_mdx_player
+examples/simple_mdx_player/simple_mdx_player.exe


### PR DESCRIPTION
The example was renamed in 353680f8d1261fdad6e7d6b6c1e8c1f80c217a5a, but the gitignore still uses the old name.