### PR TITLE
fixed implementation of L_1C

### DIFF
--- a/src/mxdrv/mxdrv.cpp
+++ b/src/mxdrv/mxdrv.cpp
@@ -2787,7 +2787,7 @@ L00040e:;
 														move.b  (a2)+,(a1)+
 */
 	D6 &= 0x00000001;
-	if ( D1 == 0 ) goto L000416;
+	if ( D6 == 0 ) goto L000416;
 #if MXDRV_ENABLE_PORTABLE_CODE
 	*TO_PTR(A1++) = *TO_PTR(A2++);
 #else
@@ -2850,7 +2850,7 @@ L00042c:;
 														swap.w  d5
 */
 
-//L000440:;
+L000440:;
 /*
 														move.l  (a0),d0
 														beq     L000446
@@ -2873,9 +2873,7 @@ L000446:;
 #else
 	A0 = (UBYTE *)(((ULONG *)A0)+2);
 #endif
-	if ( (D2--) > 0 ) goto L000426;
-	D5 >>= 3;
-	D5--;
+	if ( (D5--) > 0 ) goto L000440;
 	D0 = (ULONG)A1;
 
 L000454:;


### PR DESCRIPTION
## 概要

MXDRVコマンド0x1C(L_1C)でのPDXバッファのマージ処理不具合を修正。

### 分岐条件で参照するレジスタの誤り

ロングワード・ワード単位でブロックコピーを行った後、端数の1バイトをコピーするかどうかを判定する処理があります。

```asm
and.w   #$0001,d6
beq     L000416
move.b  (a2)+,(a1)+
```

本来はD6を参照すべきところ、移植コードではD1を参照しています。
そのため、端数バイトの有無に関係なくコピーがスキップされる場合があります。

### 第2オフセット修正ループの不具合

バッファ挿入後、エントリのオフセット値を補正するループが2つあります。

| ループ | カウンタ | 先頭ラベル | 用途 |
|--------|---------|-----------|------|
| 第1ループ | D2 | L000426 | MDXエントリのオフセット修正 |
| 第2ループ | D5 | L000440 | PDXエントリのオフセット修正 |

第2ループの終了処理が第1ループ側に分岐する状態になっています。
その結果、第2ループが実行されず、PDXエントリのオフセットが更新されません。
そのため、マージ後のADPCMデータのアドレスが不正になります。