### PR TITLE
fixed implementation of L_1B

### DIFF
--- a/src/mxdrv/mxdrv.cpp
+++ b/src/mxdrv/mxdrv.cpp
@@ -2330,7 +2330,7 @@ L0002ac:;
 	if ( (D0--) != 0 ) goto L0002ac;
 	D2 &= 0xffff0001;
 	if ( (D2 & 0xffff) == 0 ) goto L0002c0;
-	a1_w = (UWORD *)a1_l; a2_w = (UWORD *)a1_l; *(--a1_w) = *(--a2_w); a1_l = (ULONG *)a1_w; a2_l = (ULONG *)a2_w;
+	a1_w = (UWORD *)a1_l; a2_w = (UWORD *)a2_l; *(--a1_w) = *(--a2_w); a1_l = (ULONG *)a1_w; a2_l = (ULONG *)a2_w;
 #if MXDRV_ENABLE_PORTABLE_CODE
 	A2 = TO_OFS(a2_l);
 #else


### PR DESCRIPTION
## 概要

MXDRVコマンド0x1B（L_1B：メモリ再配置処理）の末尾wordコピー処理で、コピー元の末尾wordが正しく転送されない不具合を修正。

### 詳細

このコマンドは、メモリブロックの移動（memmove相当）を行います。
long単位でコピーした後、転送バイト数が奇数wordの場合、末尾のwordを追加でコピーします。

```asm
move.w  -(a2),-(a1)
```

移植コードでは、末尾wordのコピー時にa2_wの初期化にa1_lが指定されていたため、コピー元ではなくコピー先のデータを再度書き込んでしまい、コピー元の末尾wordが転送されていませんでした。

```cpp
// 修正前（a2_wの初期化にa1_lを指定）
a1_w = (UWORD *)a1_l; a2_w = (UWORD *)a1_l; *(--a1_w) = *(--a2_w); a1_l = (ULONG *)a1_w; a2_l = (ULONG *)a2_w;
// 修正後（a2_wの初期化にa2_lを指定）
a1_w = (UWORD *)a1_l; a2_w = (UWORD *)a2_l; *(--a1_w) = *(--a2_w); a1_l = (ULONG *)a1_w; a2_l = (ULONG *)a2_w;
```

この不具合は、転送サイズがlong単位で割り切れず端数のwordが1つ残る場合（転送サイズのword数が奇数の場合）にのみ発生します。