### PR TITLE
fixed implementation of L001498

### DIFF
--- a/src/mxdrv/mxdrv.cpp
+++ b/src/mxdrv/mxdrv.cpp
@@ -8766,7 +8766,7 @@ static void L001498(
 														st.b    $00(a0,d0.w)
 														cmp.w   #$0009,d0
 														bcc     L0014ae
-														st.b    $27(a5,d0.w)	; L002233(d7.w)
+														st.b    $27(a5,d0.w)	; L002233(d0.w)
 */
 #if MXDRV_ENABLE_PORTABLE_CODE
 	D0 = *TO_PTR(A4++);
@@ -8778,7 +8778,7 @@ static void L001498(
 	A0[D0] = SET;
 #endif
 	if ( D0 >= 0x0009 ) goto L0014ae;
-	G.L002233[D7] = SET;
+	G.L002233[D0] = SET;
 
 L0014ae:;
 /*


### PR DESCRIPTION
## 概要

MDXコマンド0xEF(L001498)の同期信号送出処理の不具合を修正。

### 参照レジスタの誤り

同期信号の送出先チャンネルをフラグ配列L002233に記録する処理があります。

```asm
cmp.w   #$0009,d0
bcc     L0014ae
st.b    $27(a5,d0.w)    ; L002233(d7.w)
```

D0はMDXコマンドで指定された同期信号の送出先チャンネル番号で、本来はこちらを参照しますが、移植コードではD7を参照しています。
D7は現在処理中のチャンネル番号（FM：0〜8、ADPCM：9〜15）のため、意図しないエントリが書き換えられます。
また、ADPCMチャンネル（D7=9〜15）で実行された場合、D0に対する境界チェックが効かず、L002233（9バイト）の範囲外であるL00223c（OPMキーオンスロット管理領域）に書き込みが行われます。
この範囲外への書き込みにより、FM音源の音色や発音に異常が発生する可能性があります。