### PR TITLE
fixed implementation of L000b6c

### DIFF
--- a/src/mxdrv/mxdrv.cpp
+++ b/src/mxdrv/mxdrv.cpp
@@ -5174,8 +5174,8 @@ L000b6c:;
 														beq     L000b9c
 */
 	if ( (!KEY.XF4) && (!KEY.XF5) ) goto L000b82;
-	if ( KEY.XF4 ) goto L000bae;
-	if ( KEY.XF5 ) goto L000b9c;
+	if ( KEY.XF5 ) goto L000bae;
+	if ( KEY.XF4 ) goto L000b9c;
 
 L000b82:;
 /*


### PR DESCRIPTION
## 概要

L000b6c内のXF4/XF5キーの分岐先の入れ替わりを修正。

### 詳細

移植時にXF4/XF5キーの比較値が逆になっていました。

```asm
cmp.b   #$02,d7    ; XF5 → beq L000bae
cmp.b   #$01,d7    ; XF4 → beq L000b9c
```