### PR TITLE
fixed implementation of L_1B

### DIFF
--- a/src/mxdrv/mxdrv.cpp
+++ b/src/mxdrv/mxdrv.cpp
@@ -2257,7 +2257,7 @@ static void L_1B(
 	L000216();
 #endif
 	D2 = D0;
-	if ( (SLONG)d2 < 0 ) goto L0002e4;
+	if ( (SLONG)D2 < 0 ) goto L0002e4;
 	D5 = D0;
 	D0 <<= 3;
 	D3 = 0x60;
@@ -2285,7 +2285,7 @@ L00027e:;
 														swap.w  d0
 */
 	D2 -= D3;
-	if ( (SLONG)d2 >= 0 ) goto L00027e;
+	if ( (SLONG)D2 >= 0 ) goto L00027e;
 	D2 += D3;
 	if ( D2 == 0 ) goto L0002e4;
 	D3 -= D2;


### PR DESCRIPTION
## 概要

L_1B内の条件分岐の誤ったレジスタ参照を修正。

### 詳細

D2の符号で判定すべきところ、ループ中不変の退避レジスタd2を参照していました。

```asm
if ( (SLONG)d2 < 0 ) goto L0002e4;
if ( (SLONG)d2 >= 0 ) goto L00027e;
```