### PR TITLE
fixed PCM key-on flag set regardless of actual playback

### DIFF
--- a/src/mxdrv/mxdrv.cpp
+++ b/src/mxdrv/mxdrv.cpp
@@ -1071,7 +1071,9 @@ static void PCM8_SUB(
 	  case 0x0000:
 #if MXDRV_ENABLE_PORTABLE_CODE
 		X68Sound_Pcm8_Out( &context->m_impl->m_x68SoundContext, D0&0xff, TO_PTR(A1), D1, D2 );
-		context->m_impl->m_logicalSumOfKeyOnFlagsForPcm[D0&7] = true;
+		if ( D2 > 0 && (D1 & 3) != 0 ) {
+			context->m_impl->m_logicalSumOfKeyOnFlagsForPcm[D0&7] = true;
+		}
 #else
 		X68Sound_Pcm8_Out( D0&0xff, (void *)A1, D1, D2 );
 #endif
@@ -1081,7 +1083,6 @@ static void PCM8_SUB(
 		  case 0x0100:
 #if MXDRV_ENABLE_PORTABLE_CODE
 			X68Sound_Pcm8_Out( &context->m_impl->m_x68SoundContext, D0&0xff, 0, 0, 0 );
-			context->m_impl->m_logicalSumOfKeyOnFlagsForPcm[D0&7] = true;
 #else
 			X68Sound_Pcm8_Out( D0&0xff, 0, 0, 0 );
 #endif
@@ -1151,7 +1152,9 @@ static void ADPCMOUT(
 	} else {
 //		printf("invalid A1 %08X\n", A1);
 	}
-	context->m_impl->m_logicalSumOfKeyOnFlagsForPcm[0] = true;
+	if ( D2 > 0 ) {
+		context->m_impl->m_logicalSumOfKeyOnFlagsForPcm[0] = true;
+	}
 #else
 	_iocs_adpcmout( (void *)A1, D1, D2 );
 #endif


### PR DESCRIPTION
## 概要

実際には発音しないPCM出力呼び出しでもキーオンフラグが立っていたのを修正。

### 詳細

X68Soundの`Pcm8::Out`は`len > 0`かつ`mode & 3 != 0`のときだけ再生を開始します。
しかし`m_logicalSumOfKeyOnFlagsForPcm`はその条件に関係なく常に`true`になっていたため、スラー継続、モード設定のみの呼び出し、len=0の停止コマンド（`case 0x0100`）でもフラグが立っていました。
`case 0x0000`と`ADPCMOUT`は発音開始条件を満たす場合のみフラグを立てるよう修正し、`case 0x0100`はフラグ設定の行ごと削除しました。