### PR TITLE
fixed implementation of L_1B and L_1C

### DIFF
--- a/src/mxdrv/mxdrv.cpp
+++ b/src/mxdrv/mxdrv.cpp
@@ -2413,7 +2413,7 @@ L0002e4:;
 														movem.l (sp)+,d1-d5/a0-a2
 														rts
 */
-	D1 = D0;
+	D0 = D1;
 	D1=d1, D2=d2, D3=d3, D4=d4, D5=d5, A0=a0, A1=a1, A2=a2;
 
 }
@@ -2747,7 +2747,7 @@ L0003ea:;
 #endif
 	D6 -= D4;
 	D1 = D6;
-	D2 >>= 2;
+	D1 >>= 2;
 	D1 --;
 #if MXDRV_ENABLE_PORTABLE_CODE
 	a2_l = (ULONG volatile *)TO_PTR(A2); a1_l = (ULONG volatile *)TO_PTR(A1);


### PR DESCRIPTION
## 概要

同期演奏のバッファマージ機能で使われる`L_1B`/`L_1C`のレジスタ取り違えを2件修正。

`L_1B`と`L_1C`はいずれも同期演奏（複数MDXファイルの結合ロード）機能で使用されています。同一機能内の修正のため、1つのPRにまとめました。

### 詳細

#### L_1B

関数末尾の`move.l d1,d0`が逆方向になっていました。
`L_1B`（バッファ内データの移動/挿入処理）の戻り値`D0`が正しく設定されず、呼び出し元の`L_1C`がバッファマージの成否を不定値で判定してしまいます。

#### L_1C

`lsr.l #2,d1`が`D2`に対して行われていました。
直後の32bitコピーループ回数が本来の`(D6>>2)-1`ではなく`D6-1`になり、約4倍のデータをコピーしてバッファ境界を越えて読み書きしてしまいます。