### PR TITLE
fixed implementation of L_14

### DIFF
--- a/src/mxdrv/mxdrv.cpp
+++ b/src/mxdrv/mxdrv.cpp
@@ -1609,7 +1609,7 @@ static void L_14(
 	void
 #endif
 ) {
-	D0 = ~G.L001e06;
+	D0 = (UWORD)~G.L001e06;
 }
 
 


### PR DESCRIPTION
## 概要

`L_14`（チャンネルイネーブル状態取得）で、整数昇格により戻り値の上位16bitが意図せず反転していた箇所を修正。

### 詳細

`G.L001e06`は`uint16_t`、`D0`は32bitの`ULONG`です。`D0 = ~G.L001e06;`は整数昇格により、まず32bitの`int`に昇格してから全32bitを反転するため、本来0のはずの上位16bitが0xFFFFになっていました。実機の`not.w d0`は下位16bitのみ反転し、上位16bitは変化しません。

例えば`G.L001e06 == 0x1234`のとき、実機の結果は`D0 = 0x0000EDCB`ですが、これまでのコードは`D0 = 0xFFFFEDCB`を返していました。修正後は`(UWORD)~G.L001e06`として下位16bitのみを反映します。